### PR TITLE
Updated for newer versions of Template Haskell

### DIFF
--- a/plumbers.cabal
+++ b/plumbers.cabal
@@ -1,5 +1,5 @@
 Name:                plumbers
-Version:             0.0.3
+Version:             0.0.4
 Cabal-Version:       >= 1.6
 Synopsis:            Pointless plumbing combinators
 Category:            ACME
@@ -15,7 +15,7 @@ Source-repository head
   location:          git://github.com/mgsloan/plumbers.git
 
 Library
-  Extensions:        TemplateHaskell
+  Extensions:        TemplateHaskell, CPP
   Build-Depends:     base >= 4.2 && < 5,
                      template-haskell >= 2.4 && < 3
   Hs-source-dirs:    src

--- a/src/Control/Plumbers/Specs.hs
+++ b/src/Control/Plumbers/Specs.hs
@@ -17,7 +17,11 @@ module Control.Plumbers.Specs where
 import Control.Plumbers.TH
 
 import Language.Haskell.TH
+#if MIN_VERSION_template_haskell(2,10,0)
+  (Exp(TupE), Type(AppT, ForallT, ConT), mkName)
+#else
   (Exp(TupE), Type(AppT, ForallT), Pred(ClassP), mkName)
+#endif
 
 productSpec :: PlumberSpec
 productSpec     = (baseSpec "*" "_") { plumberTypes = Just productTypes
@@ -77,6 +81,10 @@ fbindTypes b = addMonadContext . addBaseContext $ baseTypes
 addMonadContext x = x { resultType = addForalls mforall               $ resultType x }
  where
   m = mkVT "m"
+#if MIN_VERSION_template_haskell(2,10,0)
+  mforall = (ForallT [mkVB "m"] [AppT (ConT $ mkName "Monad") m] undefined)
+#else
   mforall = (ForallT [mkVB "m"] [ClassP (mkName "Monad") [m]] undefined)
+#endif
 
 addBaseContext x = x { resultType = addForalls (resultType baseTypes) $ resultType x }


### PR DESCRIPTION
As of Template Haskell 2.10.0, `Pred` is a synonym for `Type`. This patch updates `plumbers` for newer versions of TH.